### PR TITLE
Fixed bug related to resize and view more props initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Module version changes and fixes.
 
+
+## 2.0.2
+
+`Users are safe to upgrade to 2.0.2 from any lower version without any module level changes.`
+
+- Fixed a non-impact bug related to View More Input props
+- Added resize listener to adjust the width of dropdownlist during resize events. Resize event listener will be destroyed once dropdown list is closed on select or onBlur.
+- Upgrade to this package is recommended for better interactivity.
+
 ## 2.0.1
 
 `Users are safe to upgrade to 2.0.1 from any lower version without any module level changes.`
@@ -10,7 +19,6 @@
 - Renamed the internal class `loader`  to `autocomplete-plugin-loader` as `loader` class is too common name and may collide with other libraries.
 - By default `showLoadingSpinner` marked as `true` in `2.0.1` . Spinner will be shown by default, if lazy loading / API calls are configured. It can be passed as `false` through input props if not required.
 - Updated Readme file and stackblitz examples.
-- Upgrade to this package is recommended.
 
 ## 2.0.0
 - Search algorithm has been updated for better search results. No change in types or schema. Upgrading from `1.0.1` to `2.0.0`is safe without any impact.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ React 16.8+, 17, 18 or higher which has `react hooks` support.
 
 | Package version | Description | 
 | :-------- | :-----------|
-| `2.0.1` | Recommended. Added View More feature for lazy loading API calls. Upgrading from lower versions to `2.0.1` is safe without any configuration change |
+| `2.0.2` | Recommended. Fixed a non-impact bug related to View More Input props. Added resize listener to adjust the width of dropdownlist during resize events. Resize event listener will be destroyed once dropdown list is closed on select or onBlur |
+| 2.0.1 | Added View More feature for lazy loading API calls. Upgrading from lower versions to `2.0.1` is safe without any configuration change |
 | 2.0.0  | Search algorithm has been updated for better search results. No change in types or schema. Upgrading from `1.0.1` to `2.0.0`is safe without any impact. |
 | 1.0.1   | Autocomplete search package |
 
-## What's new in 2.0.1 ?
+## What's new in ^2.0.0 ?
 
 - Added `View More` to List dropdown at the end of the list as an alternative to call API when reaching the end of scroll with configurable options.
 - Now the developers who consume this package can decide how they should trigger an API Call. Using `View More`, or triggering API Call when reaching end of scroll. Both can be configured as well. Refer below for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autocomplete-plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "nodeworld",
   "description": "A simple, powerful, lightweight and customizable autocomplete tool programmed for React projects!",
   "license": "MIT",

--- a/src/components/Autocomplete/Core.tsx
+++ b/src/components/Autocomplete/Core.tsx
@@ -79,14 +79,29 @@ function Core(props: InputFieldType) {
 
     const viewMoreText = props.viewMoreText ? props.viewMoreText : 'View More';
 
-    const showViewMore = (props.showViewMore !== undefined && props.showViewMore !== null) ? props.isScrollThresholdRequired : true;
+    const showViewMore = (props.showViewMore !== undefined && props.showViewMore !== null) ? props.showViewMore : true;
 
     const showLoadingSpinner = (props.showLoadingSpinner !== undefined && props.showLoadingSpinner !== null) ? props.showLoadingSpinner : true;
+
+    function setWidth() {
+        const getListId = document.getElementById('autoCompleteListContainerId')?.style;
+        const getInputId = document.getElementById('searchInput')?.clientWidth;
+        if (getListId && getInputId) {
+            getListId.width = getInputId+'px';
+        }
+        return;
+    }
+    
+    const resizeListener = useCallback(() => {
+        setWidth();
+    }, []);
 
 
     const handleOnFocusEvent = (event: any) => {
         if (props.isAutoCompleteDisabled) { return; }
         setisOnFocus(true);
+        setWidth();
+        window.addEventListener("resize", resizeListener);
         const getListId = document.getElementById('autoCompleteListContainerId')?.style;
         const getInputId = document.getElementById('searchInput')?.clientWidth;
         if (getListId && getInputId) {
@@ -112,6 +127,7 @@ function Core(props: InputFieldType) {
             searchValue.current!.value = selectedValue;
         }
         setisOnFocus(false);
+        window.removeEventListener("resize", resizeListener);
         setInputFieldDirty(false);
         setFilteredData([]);
         setSearchedData([]);
@@ -138,6 +154,7 @@ function Core(props: InputFieldType) {
         }
         setisOnFocus(false);
         setFilteredData([]);
+        window.removeEventListener("resize", resizeListener);
         if (props.triggerBlurEvent && typeof props.triggerBlurEvent === 'function') {
             props.triggerBlurEvent(event)
         }


### PR DESCRIPTION
1. Fixed a non-impact bug related to View More Input props
2. Added resize listener to adjust the width of dropdownlist during resize events. Resize event listener will be destroyed once dropdown list is closed on select or onBlur.